### PR TITLE
feat(typescript): add "node" debug adapter

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/typescript.lua
+++ b/lua/lazyvim/plugins/extras/lang/typescript.lua
@@ -1,3 +1,7 @@
+local debugtypePreferred = {
+  ['node'] = 'pwa-node',
+}
+
 return {
 
   -- add typescript to treesitter
@@ -87,6 +91,18 @@ return {
           },
         }
       end
+      if not dap.adapters['node'] then
+        dap.adapters['node'] = function (cb, config)
+          config.type = debugtypePreferred[config.type] or config.type
+          local nativeAdapter = dap.adapters['pwa-node']
+          if type(nativeAdapter) == 'function' then
+            nativeAdapter(cb, config )
+          else
+            cb(nativeAdapter)
+          end
+        end
+      end
+
       for _, language in ipairs({ "typescript", "javascript", "typescriptreact", "javascriptreact" }) do
         if not dap.configurations[language] then
           dap.configurations[language] = {


### PR DESCRIPTION
add "node" debug adapter for compatibility with .vscode/launch.json

"pwa-" prefixed debug types are deprecated in the debug adapter. ref: https://github.com/microsoft/vscode-js-debug/pull/1305

Also, vscode generates launch.json files with "type": "node" by default now, and warns if we use "pwa-node"

This PR adds support for "node" dap adapter/debugtype which maps to "pwa-node". This behaviour is same as of the upstream debug adapter's supporting extension